### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,35 +1,14 @@
-## Core team
-modules/openapi-generator/src/main/java/org/openapitools/codegen/*.java @OpenAPITools/generator-core-team
-modules/openapi-generator/src/main/java/org/openapitools/codegen/auth/*.java @OpenAPITools/generator-core-team
-modules/openapi-generator/src/main/java/org/openapitools/codegen/config/*.java @OpenAPITools/generator-core-team
-modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/*.java @OpenAPITools/generator-core-team
-modules/openapi-generator/src/main/java/org/openapitools/codegen/ignore/**/*.java @OpenAPITools/generator-core-team
-modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/*.java @OpenAPITools/generator-core-team
-modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/**/*.java @OpenAPITools/generator-core-team
-modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/**/*.java @OpenAPITools/generator-core-team
-modules/openapi-generator-core/**/* @OpenAPITools/generator-core-team
+# Default code owners
+*                           @openebs/mayastor-approvers
 
-# No need for auto-generated subdirectories (reduces noise)
-docs/ @OpenAPITools/generator-core-team
+# CODEOWNERS file owners
+/.github/CODEOWNERS         @openebs/org-maintainers
 
-## Individual interests
-.github/**/* @jimschubert
-scripts/**/* @jimschubert
-website/**/* @jimschubert
-bin/ci/**/* @jimschubert
-
-## Build related
-CI/**/* @OpenAPITools/build
-.mvn/**/* @OpenAPITools/build
-bin/utils/**/* @OpenAPITools/build
-
-## Module-specific
-modules/openapi-generator-cli/**/* @jimschubert
-modules/openapi-generator-gradle-plugin/**/* @jimschubert
-modules/openapi-generator-maven-plugin/**/* @jimschubert
-
-# Martin Delille
-/Users/martin/dev/clone/openapi-generator/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQtClientCodegen.java @martindelille
-/Users/martin/dev/clone/openapi-generator/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQtAbstractCodegen.java @martindelille
-/Users/martin/dev/clone/openapi-generator/modules/openapi-generator/src/main/resources/cpp-qt-client @martindelille
-/Users/martin/dev/clone/openapi-generator/samples/client/petstore/cpp-qt @martindelille
+# Policy docs owners
+/CODE_OF_CONDUCT.md         @openebs/org-maintainers
+/CONTRIBUTING.md            @openebs/org-maintainers
+/GOVERNANCE.md              @openebs/org-maintainers
+/LICENSE                    @openebs/org-maintainers
+/MAINTAINERS.md             @openebs/org-maintainers
+/SECURITY.md                @openebs/org-maintainers
+/SECURITY_CONTACTS.md       @openebs/org-maintainers


### PR DESCRIPTION
Removes upstream CODEOWNERS entries and adds OpenEBS team entries.